### PR TITLE
Add getMessages to MessageDeliveryController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
 - oraclejdk8
 script:
 - sbt clean test riffRaffUpload
+branches:
+  only:
+    - master
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/common/app/services/RedisMessageDatabase.scala
+++ b/common/app/services/RedisMessageDatabase.scala
@@ -25,7 +25,7 @@ object RedisMessage {
   implicit val redisMessageFormat = Json.format[RedisMessage]
 
   implicit val formatter = new ByteStringFormatter[RedisMessage] {
-    override def serialize(redisMessage: RedisMessage) : ByteString = {
+    override def serialize(redisMessage: RedisMessage): ByteString = {
       ByteString(Json.stringify(Json.toJson(redisMessage)))}
 
     override def deserialize(bs: ByteString): RedisMessage = {

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -1,14 +1,47 @@
 package controllers
 
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.libs.json.{JsArray, JsObject, JsString, Json}
 import play.api.mvc.{Action, Controller}
+import services.{Logging, RedisMessageDatabase}
+import workers.GCMMessage
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 @Singleton
-class MessageDeliveryController extends Controller {
+class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends Controller with Logging {
+
+  val gcmMessageForm = Form(
+    mapping(
+      "clientId" -> nonEmptyText,
+      "topic" -> nonEmptyText,
+      "title" -> nonEmptyText,
+      "body" -> nonEmptyText
+    )(GCMMessage.apply)(GCMMessage.unapply))
 
   def index = Action {
     Ok("Index OK from Message Delivery")
   }
+
+  def getMessage(gcmBrowserId: String) = Action.async { implicit request =>
+    redis.getMessages(gcmBrowserId).map {
+      case Nil =>
+        log.warn(s"Could not retrieve latest message for $gcmBrowserId")
+        NotFound(JsObject(Seq("status" -> JsString("not found"))))
+      case messages =>
+        Ok(JsObject(
+          Seq("status" -> JsString("ok"),
+              "messages" -> JsArray(messages.map{ message => Json.toJson(message)}))))}}
+
+  def saveRedisMessage() = Action.async { implicit request =>
+    gcmMessageForm.bindFromRequest.fold(
+      errors => Future.successful(BadRequest),
+      gcmMessage =>
+        redis.leaveMessageWithDefaultExpiry(gcmMessage).map(_ => Ok))}
 
 }

--- a/messagedelivery/conf/routes
+++ b/messagedelivery/conf/routes
@@ -1,3 +1,6 @@
 GET / controllers.MessageDeliveryController.index()
 
+GET /messages/:browserId controllers.MessageDeliveryController.getMessage(browserId)
+POST /messages/create controllers.MessageDeliveryController.saveRedisMessage()
+
 GET /_healthcheck controllers.Healthcheck.healthcheck()


### PR DESCRIPTION
This adds the methods for getting messages for a specific `browerId` from `redis`.

It adds two endpoints:
 - `GET /messages/:browserId`
 - `POST /messages/:browserId`
 - `POST /messages/create`

The `GET` endpoint will be removed in the future.
The `POST /messages/create` endpoint takes the format of `GCMMessage`.

@NathanielBennett 