### PR TITLE
Live blog key events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,10 @@ lazy val common = (project in file("./common"))
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20",
       "com.google.gcm" % "gcm-server" % "1.0.0",
-      "com.github.etaty" %% "rediscala" % "1.6.0"
+      "com.github.etaty" %% "rediscala" % "1.6.0",
+      "org.julienrf" % "play-json-derived-codecs_2.11" % "3.1",
+      "com.gu" %% "content-api-client" % "7.24",
+      "org.scalatest" %% "scalatest" % "2.2.6" % "test"
     )
   )
   .enablePlugins(PlayScala)
@@ -35,8 +38,7 @@ lazy val capiEventWorker = (project in file("./capieventworker"))
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20",
-      "com.amazonaws" % "amazon-kinesis-client" % "1.6.1",
-      "com.gu" %% "content-api-client" % "7.24"
+      "com.amazonaws" % "amazon-kinesis-client" % "1.6.1"
     ),
     routesGenerator := InjectedRoutesGenerator,
     packageName in Universal := normalizedName.value,

--- a/capieventworker/app/services/Firehose.scala
+++ b/capieventworker/app/services/Firehose.scala
@@ -11,7 +11,8 @@ import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason
 import com.amazonaws.services.kinesis.metrics.impl.NullMetricsFactory
 import com.amazonaws.services.kinesis.model.Record
 import config.Config
-import workers.{MessageWorker, PublishedMessage}
+import model.{KeyEvent, LiveBlogUpdateEvent}
+import workers.MessageWorker
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
@@ -75,7 +76,7 @@ class RecordProcessor(messageWorker: MessageWorker) extends IRecordProcessor wit
           if (tags.exists(_ == "tone/minutebyminute")) {
             ServerStatistics.capiEventsProcessed.incrementAndGet()
             log.info(s"Putting ${content._4.id} onto queue!")
-            messageWorker.queue.send(PublishedMessage(content._4.id))}
+            messageWorker.queue.send(LiveBlogUpdateEvent(content._4.id, KeyEvent.fromContent(content.content)))}
         case Failure(t) =>
           log.error(s"Could not deserialize message: $t")
       }

--- a/common/app/model/Update.scala
+++ b/common/app/model/Update.scala
@@ -1,0 +1,34 @@
+package model
+
+import com.gu.contentapi.client.model.v1.Content
+import julienrf.json.derived
+import play.api.libs.json.{Json, Format}
+
+import scala.util.Try
+
+case class KeyEvent(id: String, title: Option[String], body: String)
+
+object KeyEvent {
+  implicit val implicitFormat: Format[KeyEvent] = Json.format[KeyEvent]
+
+  def fromContent(content: Content): List[KeyEvent] =
+    content.blocks
+      .flatMap(_._2)
+      .getOrElse(Nil)
+      .filter(_.attributes.keyEvent.exists(identity))
+      .filter(_.published)
+      .map(block => KeyEvent(block.id, block.title, block.bodyTextSummary))
+      .toList
+      .reverse
+
+  def getLastestKeyEvents(lastKeyEventId: String, keyEvents: List[KeyEvent]): List[KeyEvent] =
+    Try(keyEvents.dropWhile(_.id != lastKeyEventId).tail).toOption.getOrElse(Nil)
+}
+
+sealed trait Update
+case class PublishedMessage(topic: String) extends Update
+case class LiveBlogUpdateEvent(topic: String, keyEvents: List[KeyEvent]) extends Update
+
+object Update {
+  implicit val implicitFormat: Format[Update] = derived.oformat
+}

--- a/common/app/services/LastSentDatabase.scala
+++ b/common/app/services/LastSentDatabase.scala
@@ -15,8 +15,15 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
+sealed trait LastSent
 
-case class LastSent(topic: String, dateTime: DateTime)
+case class LastSentDateOnly(topic: String, dateTime: DateTime) extends LastSent
+
+object LastSentDateOnly {
+  def emptyForTopic(topic: String): LastSent = LastSentDateOnly(topic, DateTime.now())
+}
+
+case class LastSentKeyEvent(topic: String, dateTime: DateTime, keyEventId: Option[String]) extends LastSent
 
 object LastSent {
   implicit object LastSentDynamoFormat extends DynamoFormat[LastSent] {
@@ -25,21 +32,48 @@ object LastSent {
         Option(value.getM).map(_.asScala.toMap)
           .getOrElse(Map.empty)
 
-      for {
-        topic <- valueMap.get("topic").flatMap(av => Option(av.getS))
-        dateTime <- valueMap.get("dateTime")
-          .flatMap(av => Option(av.getN))
-          .map(_.toLong)
-          .map(l => new DateTime(l * 1000))
-      } yield LastSent(topic, dateTime)
+      valueMap.get("type").flatMap(av => Option(av.getS)) match {
+        case Some("lastSentDateOnly") =>
+          for {
+            topic <- valueMap.get("topic").flatMap(av => Option(av.getS))
+            dateTime <- valueMap.get("dateTime")
+              .flatMap(av => Option(av.getN))
+              .map(_.toLong)
+              .map(l => new DateTime(l * 1000))
+          } yield LastSentDateOnly(topic, dateTime)
+        case Some("lastSentKeyEvent") =>
+          for {
+            topic <- valueMap.get("topic").flatMap(av => Option(av.getS))
+            dateTime <- valueMap.get("dateTime")
+              .flatMap(av => Option(av.getN))
+              .map(_.toLong)
+              .map(l => new DateTime(l * 1000))
+            keyEvent = valueMap.get("keyEvent").flatMap(av => Option(av.getS))
+          } yield LastSentKeyEvent(topic, dateTime, keyEvent)
+        case _ => None
+      }
+
+
     }
 
     override def write(value: LastSent): AttributeValue = {
-      new AttributeValue().withM(
-        Map(
-          "topic" -> new AttributeValue().withS(value.topic),
-          "dateTime" -> new AttributeValue().withN((value.dateTime.getMillis / 1000).toString)
-        ).asJava)
+      value match {
+        case lastSentDateOnly: LastSentDateOnly =>
+          new AttributeValue().withM(
+            Map(
+              "type" -> new AttributeValue().withS("lastSentDateOnly"),
+              "topic" -> new AttributeValue().withS(lastSentDateOnly.topic),
+              "dateTime" -> new AttributeValue().withN((lastSentDateOnly.dateTime.getMillis / 1000).toString)
+            ).asJava)
+        case lastSentKeyEvent: LastSentKeyEvent =>
+          val attributeMap = Map(
+            "type" -> new AttributeValue().withS("lastSentKeyEvent"),
+            "topic" -> new AttributeValue().withS(lastSentKeyEvent.topic),
+            "dateTime" -> new AttributeValue().withN((lastSentKeyEvent.dateTime.getMillis / 1000).toString))
+
+          new AttributeValue().withM(
+            lastSentKeyEvent.keyEventId.fold(attributeMap)(s => attributeMap + ("keyEvent" -> new AttributeValue().withS(s))).asJava)
+      }
     }
   }
 }

--- a/common/app/workers/MessageWorker.scala
+++ b/common/app/workers/MessageWorker.scala
@@ -5,16 +5,11 @@ import javax.inject.{Inject, Singleton}
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import config.Config
-import play.api.libs.json.Json
+import model.{KeyEvent, PublishedMessage, LiveBlogUpdateEvent, Update}
+import org.joda.time.DateTime
 import services._
 
 import scala.concurrent.Future
-
-object PublishedMessage {
-  implicit val implicitFormat = Json.format[PublishedMessage]
-}
-
-case class PublishedMessage(topic: String) extends AnyVal
 
 @Singleton
 class MessageWorker @Inject() (
@@ -22,34 +17,74 @@ class MessageWorker @Inject() (
   gcmWorker: GCMWorker,
   redisMessageDatabaseModule: RedisMessageDatabaseModule,
   clientDatabase: ClientDatabase,
-  lastSentDatabase: LastSentDatabase) extends JsonQueueWorker[PublishedMessage] with Logging {
+  lastSentDatabase: LastSentDatabase) extends JsonQueueWorker[Update] with Logging {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val redisMessageDatabase: RedisMessageDatabase = redisMessageDatabaseModule.redisMessageDatabase
 
-  override val queue: JsonMessageQueue[PublishedMessage] =
-    JsonMessageQueue[PublishedMessage](
+  override val queue: JsonMessageQueue[Update] =
+    JsonMessageQueue[Update](
       new AmazonSQSAsyncClient(
         new DefaultAWSCredentialsProviderChain()).withRegion(config.workerQueueRegion),
       config.messageWorkerQueue)
 
-  override def process(message: SQSMessage[PublishedMessage]): Future[Unit] = {
-    val PublishedMessage(topic: String) = message.get
-
-    log.info(s"Processing job for topic $topic")
-
+  override def process(message: SQSMessage[Update]): Future[Unit] = {
     ServerStatistics.recordsProcessed.incrementAndGet()
+    message.get match {
+      case PublishedMessage(topic: String) =>
+        log.info(s"Processing job for PublishedMessage($topic)")
 
-    lastSentDatabase.updateTopic(topic).flatMap {
-      case lastSentDatabase.ShouldNotSend => Future.successful(())
-      case lastSentDatabase.ShouldSend =>
-        clientDatabase.getIdsByTopic(topic).map { listOfBrowserIds =>
-          listOfBrowserIds.foreach { browserId =>
-            val gcmMessage: GCMMessage = GCMMessage(browserId.get, topic, s"Message for $topic", s"You got a new notification for $topic")
-            redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
-              ServerStatistics.gcmMessagesSent.incrementAndGet()
-              gcmWorker.queue.send(List(gcmMessage))}}}
-    }
+        lastSentDatabase.checkTopicAndUpdateIfPasses(topic, LastSentDateOnly.emptyForTopic(topic)){
+          case LastSentDateOnly(t, dateTime)
+            if DateTime.now.minusMinutes(2).isAfter(dateTime) => Option(LastSentDateOnly(t, DateTime.now))
+          case _ => None
+        }{
+          case LastSentDateOnly(t, dateTime) =>
+            clientDatabase.getIdsByTopic(t).map { listOfBrowserIds =>
+              listOfBrowserIds.foreach { browserId =>
+                val gcmMessage: GCMMessage = GCMMessage(browserId.get, t, s"Message for $t", s"You got a new notification for $t")
+                redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
+                  ServerStatistics.gcmMessagesSent.incrementAndGet()
+                  gcmWorker.queue.send(List(gcmMessage))}}}
 
+            case _ => Future.successful(())}
+
+      case LiveBlogUpdateEvent(topic, keyEvents) =>
+        log.info(s"Processing job for LiveBlogUpdateEvent($topic)(${keyEvents.length} key events)")
+
+        lazy val emptyLastSentKeyEvent: LastSentKeyEvent = LastSentKeyEvent(topic, DateTime.now(), keyEvents.lastOption.map(_.id))
+
+        lastSentDatabase.lockingUpdate.lockingReadAndWriteWithCondition(id=topic, empty=emptyLastSentKeyEvent){
+          case ke@LastSentKeyEvent(t, dateTime, Some(lastKeyEventId)) =>
+            log.info(s"Last sent to $topic at $dateTime with lastKeyEventId: $lastKeyEventId")
+            KeyEvent.getLastestKeyEvents(lastKeyEventId, keyEvents).lastOption.map(lastKeyEvent => LastSentKeyEvent(t, DateTime.now(), Option(lastKeyEvent.id)))
+          case ke@LastSentKeyEvent(t, dateTime, None) =>
+            log.info(s"Never sent to topic $topic before")
+            keyEvents.lastOption.map(keyEvent => LastSentKeyEvent(t, DateTime.now(), Some(keyEvent.id)))
+          case t =>
+            log.warn(s"Got the wrong type for $topic: $t")
+            None}
+        .map {
+          case lastSentDatabase.lockingUpdate.ReadAndWrite(LastSentKeyEvent(t, _, Some(lastKeyEventId)), newItem) =>
+            val newKeyEvents: List[KeyEvent] = KeyEvent.getLastestKeyEvents(lastKeyEventId, keyEvents)
+            log.info(s"Sending ${newKeyEvents.length} new events to $topic (Out of ${keyEvents.length} possible events)")
+            sendKeyEvents(t, newKeyEvents)
+          case lastSentDatabase.lockingUpdate.NewItem(LastSentKeyEvent(t, _, _)) =>
+            log.info(s"Never seen $t before; sending all ${keyEvents.length} key events")
+            sendKeyEvents(t, keyEvents)
+          case t =>
+            log.warn(s"Did not sent any events for $topic: DB Result: $t")}}
   }
+
+  private def sendKeyEvents(topic: String, keyEvents: List[KeyEvent]): Future[Unit] =
+    clientDatabase.getIdsByTopic(topic).map { listOfBrowserIds =>
+      log.info(s"There are ${listOfBrowserIds.size} browers to notify for $topic")
+      listOfBrowserIds.foreach { browserId =>
+        keyEvents.map { keyEvent =>
+          val topicMessage: String = keyEvent.title.getOrElse(s"Message for $topic")
+          val gcmMessage: GCMMessage = GCMMessage(browserId.get, topic, topicMessage, keyEvent.body)
+          redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
+            ServerStatistics.gcmMessagesSent.incrementAndGet()
+            gcmWorker.queue.send(List(gcmMessage))}}}}
+
 }


### PR DESCRIPTION
This adds the sending of **key events** from a LiveBlog to clients subscribed clients.

### How it works

For each `LiveBlog` update, we check to see if there has already been a send for the past update. If so we get all new key events since the last send and send those; otherwise if it's new, we send out all the key events on the live blog.

There is no time restriction on this. If there are two key events within 5 seconds you will get both.

### Other changes

I have extended it in a way that allows us to have different types of update in the future; such as series or maybe something else.

@NathanielBennett @crifmulholland 

