### PR TITLE
add block-id to click handler

### DIFF
--- a/common/app/services/MessageDatabase.scala
+++ b/common/app/services/MessageDatabase.scala
@@ -32,8 +32,9 @@ class MessageDatabase @Inject()(
                 Map(
                   "topic" -> new AttributeValue().withS(gcmMessage.topic),
                   "title" -> new AttributeValue().withS(gcmMessage.title),
-                  "body" -> new AttributeValue().withS(gcmMessage.body)
-                ).asJava))
+                  "body" -> new AttributeValue().withS(gcmMessage.body),
+                  "blockId" -> new AttributeValue().withS(gcmMessage.blockId)
+              ).asJava))
           ).asJava)
 
     dynamoDBClient.putItemFuture(putItemRequest)

--- a/common/app/services/RedisMessageDatabase.scala
+++ b/common/app/services/RedisMessageDatabase.scala
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class RedisMessage(topic: String, title: String, body: String, time: Long)
+case class RedisMessage(topic: String, title: String, body: String, blockId: String, time: Long)
 
 object RedisMessage {
   implicit val redisMessageFormat = Json.format[RedisMessage]
@@ -35,7 +35,7 @@ object RedisMessage {
   }
 
   def fromGcmMessage(gcmMessage: GCMMessage): RedisMessage =
-    RedisMessage(gcmMessage.topic, gcmMessage.title, gcmMessage.body, DateTime.now.getMillis / 1000)
+    RedisMessage(gcmMessage.topic, gcmMessage.title, gcmMessage.body, gcmMessage.blockId, DateTime.now.getMillis / 1000)
 }
 
 @Singleton

--- a/common/app/workers/GCMWorker.scala
+++ b/common/app/workers/GCMWorker.scala
@@ -16,7 +16,7 @@ object GCMMessage {
   implicit val implicitFormat = Json.format[GCMMessage]
 }
 
-case class GCMMessage(clientId: String, topic: String, title: String, body: String)
+case class GCMMessage(clientId: String, topic: String, title: String, body: String, blockId: String)
 
 @Singleton
 class GCMWorker @Inject()(

--- a/common/app/workers/MessageWorker.scala
+++ b/common/app/workers/MessageWorker.scala
@@ -77,7 +77,8 @@ class MessageWorker @Inject() (
       listOfBrowserIds.foreach { browserId =>
         keyEvents.map { keyEvent =>
           val topicMessage: String = keyEvent.title.getOrElse(s"Message for $topic")
-          val gcmMessage: GCMMessage = GCMMessage(browserId.get, topic, topicMessage, keyEvent.body)
+          log.info(s"Message for $topic with Id: ${keyEvent.id}")
+          val gcmMessage: GCMMessage = GCMMessage(browserId.get, topic, topicMessage, keyEvent.body, keyEvent.id)
           redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
             ServerStatistics.gcmMessagesSent.incrementAndGet()
             gcmWorker.queue.send(List(gcmMessage))}}}}

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -21,7 +21,8 @@ class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends C
       "clientId" -> nonEmptyText,
       "topic" -> nonEmptyText,
       "title" -> nonEmptyText,
-      "body" -> nonEmptyText
+      "body" -> nonEmptyText,
+      "blockId" -> nonEmptyText
     )(GCMMessage.apply)(GCMMessage.unapply))
 
   def index = Action {

--- a/messageworker/app/controllers/MessageWorkerApplication.scala
+++ b/messageworker/app/controllers/MessageWorkerApplication.scala
@@ -48,7 +48,8 @@ class MessageWorkerApplication @Inject() (
       title <- requestMap.get("title").map(_.mkString)
       body <- requestMap.get("body").map(_.mkString)
       topicId <- requestMap.get("topicId").map(_.mkString)
-    } yield GCMMessage(browserId, topicId, title, body)
+      blockId <- requestMap.get("blockId").map(_.mkString)
+    } yield GCMMessage(browserId, topicId, title, body, blockId)
 
     maybeGCMMessage match {
       case None => Future.successful(InternalServerError(s"Invalid parameters for $requestMap"))


### PR DESCRIPTION
Adds the blockid to a messsage, so that when the user clicks a notification, the link includes the hash of the block which contain the update which triggers the notification. Eg go to https://www.theguardian.com/business/live/2016/apr/01/tata-steel-crisis-uk-ringleader-china-sajid-javid-port-talbot-live**?page=with:block-56fe5c90e4b0ddd845673a08#block-56fe5c90e4b0ddd845673a08** ,not: https://www.theguardian.com/business/live/2016/apr/01/tata-steel-crisis-uk-ringleader-china-sajid-javid-port-talbot-live. Furnishes this: https://github.com/guardian/frontend/pull/12404