### PR TITLE
Remove the acme endpoint and update CORS

### DIFF
--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -29,18 +29,16 @@ class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends C
     Ok("Index OK from Message Delivery")
   }
 
-  val headerValues = Seq("Access-Control-Allow-Origin" -> "*",
+  val headerValues: Seq[(String, String)] = Seq("Access-Control-Allow-Origin" -> "*",
     "Access-Control-Allow-Headers" -> "Accept, Content-Type, Origin, Authorization",
     "Access-Control-Allow-Credentials" -> "true",
     "Access-Control-Allow-Max-Age" -> "3600",
-    "Access-Control-Allow-Methods" -> "GET, POST"
-  )
+    "Access-Control-Allow-Methods" -> "GET, POST")
 
-  private def withCors(response: Result) = response.withHeaders(headerValues:_*)
+  private def withCors(response: Result): Result = response.withHeaders(headerValues:_*)
 
   def getMessageOptions(gcmBrowserId: String) = Action { implicit request =>
-      NoContent.withHeaders(headerValues:_*)
-  }
+      NoContent.withHeaders(headerValues:_*)}
 
   def getMessage(gcmBrowserId: String) = Action.async { implicit request =>
     redis.getMessages(gcmBrowserId).map {

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -56,8 +56,4 @@ class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends C
       gcmMessage =>
         redis.leaveMessageWithDefaultExpiry(gcmMessage).map(_ => Ok))}
 
-  def acmeChallenge() = Action {
-    Ok("08eY7chzUEwYgXz6ZPPzRF4qcJ_lK-0pCrCkWX5eF0M.IJbxXz31kpvuH8KkeakzDFx6mNFUDCDY9SNC38XNA50")
-  }
-
 }

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -5,12 +5,12 @@ import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.{JsArray, JsObject, JsString, Json}
-import play.api.mvc.{Result, Action, Controller}
-import services.{RedisMessage, Logging, RedisMessageDatabase}
+import play.api.mvc.{Action, Controller, Result}
+import services.{Logging, RedisMessageDatabase}
 import workers.GCMMessage
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 
 @Singleton

--- a/messagedelivery/conf/routes
+++ b/messagedelivery/conf/routes
@@ -5,5 +5,3 @@ GET /messages/:browserId controllers.MessageDeliveryController.getMessage(browse
 POST /messages/create controllers.MessageDeliveryController.saveRedisMessage()
 
 GET /_healthcheck controllers.Healthcheck.healthcheck()
-
-GET /.well-known/acme-challenge/08eY7chzUEwYgXz6ZPPzRF4qcJ_lK-0pCrCkWX5eF0M controllers.MessageDeliveryController.acmeChallenge()


### PR DESCRIPTION
This removes the acme endpoint, it is no longer needed.

It also adds the `CORS` header to the `NotFound` response for messages.

@NathanielBennett 