### PR TITLE
Use endpoint urls

### DIFF
--- a/common/app/helper/BrowserEndpoint.scala
+++ b/common/app/helper/BrowserEndpoint.scala
@@ -1,0 +1,26 @@
+package helper
+
+sealed trait BrowserEndpoint
+case class ChromeEndpoint(get: String) extends BrowserEndpoint
+case class FirefoxEndpoint(get: String) extends BrowserEndpoint
+
+//Temporary until we move completely to endpoints
+case class GcmId(get: String) extends BrowserEndpoint
+
+object BrowserEndpoint {
+  private val ChromeEndpointPattern: String = "https://android.googleapis.com/gcm/send"
+  private val FirefoxEndpointPattern: String = "https://updates.push.services.mozilla.com/push"
+
+  def fromEndpointUrl(endpointUrl: String): Option[BrowserEndpoint] =
+    endpointUrl match {
+      case endpoint if endpoint.startsWith(ChromeEndpointPattern) => Option(ChromeEndpoint(endpoint))
+      case endpoint if endpoint.startsWith(FirefoxEndpointPattern) => Option(FirefoxEndpoint(endpoint))
+      case endpointUrl: String if !endpointUrl.startsWith("http") => Option(GcmId(endpointUrl))
+      case _ => None
+    }
+}
+
+object ChromeEndpoint {
+  def toGcmId(chromeEndpoint: ChromeEndpoint): Option[GcmId] =
+    chromeEndpoint.get.split('/').lastOption.map(GcmId)
+}

--- a/common/app/services/ClientDatabase.scala
+++ b/common/app/services/ClientDatabase.scala
@@ -37,7 +37,7 @@ class ClientDatabase @Inject()(
 
       dynamoDBClient.queryFuture(finalQueryRequest).flatMap { queryResult =>
         val newResults = results ::: queryResult.getItems.asScala.flatMap { item =>
-          item.asScala.get("gcmBrowserId").map(_.getS).flatMap(BrowserEndpoint.fromEndpointUrl)
+          item.asScala.get("browserEndpoint").map(_.getS).flatMap(BrowserEndpoint.fromEndpointUrl)
         }.toList
 
         Option(queryResult.getLastEvaluatedKey) match {

--- a/common/app/services/ClientDatabase.scala
+++ b/common/app/services/ClientDatabase.scala
@@ -7,11 +7,10 @@ import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest}
 import config.Config
+import helper.BrowserEndpoint
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
-
-case class BrowserId(get: String)
 
 @Singleton
 class ClientDatabase @Inject()(
@@ -22,9 +21,9 @@ class ClientDatabase @Inject()(
   val dynamoDBClient: AmazonDynamoDBAsyncClient = new AmazonDynamoDBAsyncClient().withRegion(Region.getRegion(Regions.EU_WEST_1))
   val TableName: String = config.ClientDatabaseTableName
 
-  def getIdsByTopic(topic: String): Future[List[BrowserId]] = {
+  def getIdsByTopic(topic: String): Future[List[BrowserEndpoint]] = {
 
-    def getQueryRequest(maybeLastEvaluatedKey: Option[java.util.Map[String, AttributeValue]], results: List[BrowserId]): Future[List[BrowserId]] = {
+    def getQueryRequest(maybeLastEvaluatedKey: Option[java.util.Map[String, AttributeValue]], results: List[BrowserEndpoint]): Future[List[BrowserEndpoint]] = {
       val queryRequest: QueryRequest =
         new QueryRequest()
           .withTableName(TableName)
@@ -38,7 +37,7 @@ class ClientDatabase @Inject()(
 
       dynamoDBClient.queryFuture(finalQueryRequest).flatMap { queryResult =>
         val newResults = results ::: queryResult.getItems.asScala.flatMap { item =>
-          item.asScala.get("gcmBrowserId").map(_.getS).map(BrowserId)
+          item.asScala.get("gcmBrowserId").map(_.getS).flatMap(BrowserEndpoint.fromEndpointUrl)
         }.toList
 
         Option(queryResult.getLastEvaluatedKey) match {

--- a/common/app/services/GCM.scala
+++ b/common/app/services/GCM.scala
@@ -5,6 +5,7 @@ import javax.inject.{Inject, Singleton}
 import com.google.android.gcm.server.Message.Builder
 import com.google.android.gcm.server.{MulticastResult, Result, Message, Sender}
 import config.Config
+import helper.GcmId
 
 import scala.concurrent.Future
 import scala.collection.JavaConverters._
@@ -28,14 +29,14 @@ class GCM @Inject()(config: Config) {
   def sendSingle(gcmNotification: GCMNotification, browserId: String): Future[Result] =
     Future.apply(gcmClient.send(GCMNotification.toMessage(gcmNotification), browserId, config.gcmSendRetries))
 
-  def sendMulticast(gcmNotification: Option[GCMNotification], listOfBrowserIds: List[BrowserId]): Future[MulticastResult] = {
+  def sendMulticast(gcmNotification: Option[GCMNotification], listOfBrowserIds: List[GcmId]): Future[MulticastResult] = {
     val message: Message = gcmNotification match {
       case None => GCMNotification.toMessage(GCMNotification("", ""))
       case Some(n) => GCMNotification.toMessage(n)}
 
     Future.apply(gcmClient.send(message, listOfBrowserIds.map(_.get).asJava, config.gcmSendRetries))}
 
-  def sendMulticastWithoutPayload(listOfBrowserIds: List[BrowserId]): Future[MulticastResult] =
+  def sendMulticastWithoutPayload(listOfBrowserIds: List[GcmId]): Future[MulticastResult] =
     sendMulticast(None, listOfBrowserIds)
 
 }

--- a/common/app/workers/GCMWorker.scala
+++ b/common/app/workers/GCMWorker.scala
@@ -6,6 +6,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.google.android.gcm.server.MulticastResult
 import config.Config
+import helper.GcmId
 import play.api.libs.json.Json
 import services._
 
@@ -33,9 +34,9 @@ class GCMWorker @Inject()(
   override def process(message: SQSMessage[List[GCMMessage]]): Future[Unit] = {
     val listOfMessages: List[GCMMessage] = message.get
 
-    val browserIds: List[BrowserId] = listOfMessages
+    val browserIds: List[GcmId] = listOfMessages
       .map(_.clientId)
-      .map(BrowserId)
+      .map(GcmId)
 
     log.info(s"Processing job for ${listOfMessages.size} clients")
     log.info(s"Processing job for $browserIds")

--- a/common/test/helper/BrowserEndpointTest.scala
+++ b/common/test/helper/BrowserEndpointTest.scala
@@ -1,0 +1,32 @@
+package helper
+
+import org.scalatest.{Matchers, FreeSpec}
+
+class BrowserEndpointTest extends FreeSpec with Matchers {
+
+  "BrowserEndpoint" - {
+    "returns ChromeEndpoint for valid chrome endpoint" in {
+      val validChromeEndpointUrl: String = "https://android.googleapis.com/gcm/send/vpn7kxGinVW9kL7ZJJZk:AAaMXNm08HpePuAfaVRmgn7xClg9pGbO98AuP7xapURTeFx_33DQt9lKWds0uaQnZv3SOy53_SZ18bMsKwN2"
+
+      BrowserEndpoint.fromEndpointUrl(validChromeEndpointUrl) should be (Some(ChromeEndpoint(validChromeEndpointUrl)))
+    }
+
+    "returns None for invalid chrome endpoint" in {
+      val validChromeEndpointUrl: String = "https://android.googleapis.com/gcm/vpn7kxGinVW9kL7ZJJZk:AAaMXNm08HpePuAfaVRmgn7xClg9pGbO98AuP7xapURTeFx_33DQt9lKWds0uaQnZv3SOy53_SZ18bMsKwN2"
+
+      BrowserEndpoint.fromEndpointUrl(validChromeEndpointUrl) should be (None)
+    }
+
+    "returns FirefoxEndpoint for a valid firefox endpoint" in {
+      val validFirefoxEndpoint: String = "https://updates.push.services.mozilla.com/push/v1/pi5CQWx8reLySO0cgAAABXC87GxcojoBe7Si9M1a7sr2Dn05NGtPA4uMVBukyk8AVj0PMrmn19i-Pv2VeCGx5L4B_OZR34"
+
+      BrowserEndpoint.fromEndpointUrl(validFirefoxEndpoint) should be (Some(FirefoxEndpoint(validFirefoxEndpoint)))
+    }
+
+    "returns None for a invalid firefox endpoint" in {
+      val validFirefoxEndpoint: String = "https://updates.push.services.mozilla.com/pi5CQWx8reLySO0cgAAABXC87GxcojoBe7Si9M1a7sr2Dn05NGtPA4uMVBukyk8AVj0PMrmn19i-Pv2VeCGx5L4B_OZR34"
+
+      BrowserEndpoint.fromEndpointUrl(validFirefoxEndpoint) should be (None)
+    }
+  }
+}

--- a/common/test/helper/ChromeEndpointTest.scala
+++ b/common/test/helper/ChromeEndpointTest.scala
@@ -1,0 +1,15 @@
+package helper
+
+import org.scalatest.{Matchers, FreeSpec}
+
+class ChromeEndpointTest extends FreeSpec with Matchers {
+
+  "ChromeEndpoint" - {
+    "returns proper ID for a valid chrome endpoint" in {
+      val validChromeEndpoint: String = "https://android.googleapis.com/gcm/send/vpn7kxGinVW9kL7ZJJZk:AAaMXNm08HpePuAfaVRmgn7xClg9pGbO98AuP7xapURTeFx_33DQt9lKWds0uaQnZv3SOy53_SZ18bMsKwN2"
+      val validChromeId: String = "vpn7kxGinVW9kL7ZJJZk:AAaMXNm08HpePuAfaVRmgn7xClg9pGbO98AuP7xapURTeFx_33DQt9lKWds0uaQnZv3SOy53_SZ18bMsKwN2"
+
+      ChromeEndpoint.toGcmId(ChromeEndpoint(validChromeEndpoint)) should be (Some(GcmId(validChromeId)))
+    }
+  }
+}

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -37,13 +37,13 @@ class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends C
 
   private def withCors(response: Result): Result = response.withHeaders(headerValues:_*)
 
-  def getMessageOptions(gcmBrowserId: String) = Action { implicit request =>
+  def getMessageOptions(browserId: String) = Action { implicit request =>
       NoContent.withHeaders(headerValues:_*)}
 
-  def getMessage(gcmBrowserId: String) = Action.async { implicit request =>
-    redis.getMessages(gcmBrowserId).map {
+  def getMessage(browserId: String) = Action.async { implicit request =>
+    redis.getMessages(browserId).map {
       case Nil =>
-        log.warn(s"Could not retrieve latest message for $gcmBrowserId")
+        log.warn(s"Could not retrieve latest message for $browserId")
         withCors(NotFound(JsObject(Seq("status" -> JsString("not found")))))
       case messages =>
         withCors(


### PR DESCRIPTION
#### Changes

This changes the application to use the full browser endpoints instead of using individual  browser IDs.

When using individual IDs, we restrict ourselves to Chrome as Chrome is the only browser we can send to with just a browser ID (using GCM).

This makes the application future proof in that it now gives room to maneuver with other User Agents/Browsers, and also makes it easier to add in functionality that adheres to the [Push API spec](https://www.w3.org/TR/push-api/), which includes encrypted payloads.

#### Browsers

Firefox 45+ and Chrome 50+ are the versions that will adhere to the same payload encrypted spec.

Internet Explorer [plans on implementing](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/pushapi) the Push API soon. Seeing as the reference the spec, I presume (hope) they won't do anything non standard like Chrome initially have done.

Safari on iOS has got a lot of speculation around it eventually supporting the standardised Push API spec; with core developers expressing interest in service worker. See [here](https://onesignal.com/blog/when-will-web-push-be-supported-in-ios/).
#### Other Changes

There will be a corresponding change on `frontend` to update records inserted to use `browserEndpoint`.

@NathanielBennett 