### PR TITLE
Change over to CAPI V2 stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,6 @@ scalaVersion := "2.11.8"
 
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies ++= Seq(
-  "org.apache.thrift" % "libthrift" % "0.9.2",
-  "com.twitter" %% "finagle-thrift" % "6.33.0",
-  "com.gu" %% "content-api-client" % "7.24"
-)
-
-
 
 lazy val common = (project in file("./common"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val common = (project in file("./common"))
       "com.google.gcm" % "gcm-server" % "1.0.0",
       "com.github.etaty" %% "rediscala" % "1.6.0",
       "org.julienrf" % "play-json-derived-codecs_2.11" % "3.1",
-      "com.gu" %% "content-api-client" % "8.2",
+      "com.gu" %% "content-api-client" % "8.5",
       "org.scalatest" %% "scalatest" % "2.2.6" % "test"
     )
   )
@@ -49,7 +49,7 @@ lazy val capiEventWorker = (project in file("./capieventworker"))
       base => base / "src/main/resources"
     },
     libraryDependencies ++= Seq(
-      "com.gu" %% "content-api-client" % "8.2",
+      "com.gu" %% "content-api-client" % "8.5",
       "com.twitter" %% "scrooge-core" % "4.6.0"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.twitter.scrooge.ScroogeSBT
 
 def env(key: String): Option[String] = Option(System.getenv(key))
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
@@ -34,7 +34,7 @@ lazy val capiEventWorker = (project in file("./capieventworker"))
   .dependsOn(common)
   .settings(
     name := "capi-event-worker",
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.twitter.scrooge.ScroogeSBT
-
 def env(key: String): Option[String] = Option(System.getenv(key))
 
 scalaVersion := "2.11.8"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val common = (project in file("./common"))
       "com.google.gcm" % "gcm-server" % "1.0.0",
       "com.github.etaty" %% "rediscala" % "1.6.0",
       "org.julienrf" % "play-json-derived-codecs_2.11" % "3.1",
-      "com.gu" %% "content-api-client" % "7.24",
+      "com.gu" %% "content-api-client" % "8.2",
       "org.scalatest" %% "scalatest" % "2.2.6" % "test"
     )
   )
@@ -43,18 +43,17 @@ lazy val capiEventWorker = (project in file("./capieventworker"))
     riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
   )
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin)
-  .settings(ScroogeSBT.newSettings: _*)
   .settings(
-    scalaVersion := "2.11.7",
-    scroogeThriftDependencies in Compile := Seq("content-api-client_2.11", "content-atom-model_2.11", "content-api-models_2.11", "story-packages-model_2.11"),
+    scalaVersion := "2.11.8",
+    scroogeThriftDependencies in Compile := Seq("content-api-models", "story-packages-model-thrift", "content-atom-model-thrift"),
     resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     resolvers += "Guardian GitHub Repository" at "http://guardian.github.io/maven/repo-releases",
     scroogeThriftSourceFolder in Compile <<= baseDirectory {
       base => base / "src/main/resources"
     },
     libraryDependencies ++= Seq(
-      "com.gu" %% "content-api-client" % "7.24",
-      "com.twitter" %% "scrooge-core" % "3.20.0"
+      "com.gu" %% "content-api-client" % "8.2",
+      "com.twitter" %% "scrooge-core" % "4.6.0"
     )
   )
 
@@ -62,7 +61,7 @@ lazy val messageWorker = (project in file("./messageworker"))
   .dependsOn(common)
   .settings(
     name := "message-worker",
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20"

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
 lazy val common = (project in file("./common"))
   .settings(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20",
@@ -44,7 +44,6 @@ lazy val capiEventWorker = (project in file("./capieventworker"))
   )
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin)
   .settings(
-    scalaVersion := "2.11.8",
     scroogeThriftDependencies in Compile := Seq("content-api-models", "story-packages-model-thrift", "content-atom-model-thrift"),
     resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     resolvers += "Guardian GitHub Repository" at "http://guardian.github.io/maven/repo-releases",
@@ -61,7 +60,6 @@ lazy val messageWorker = (project in file("./messageworker"))
   .dependsOn(common)
   .settings(
     name := "message-worker",
-    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20"
@@ -81,7 +79,6 @@ lazy val messageDelivery = (project in file("./messagedelivery"))
   .dependsOn(common)
   .settings(
     name := "message-delivery",
-    scalaVersion := "2.11.7",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20"

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val messageWorker = (project in file("./messageworker"))
   .dependsOn(common)
   .settings(
     name := "message-worker",
+    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20"
@@ -77,6 +78,7 @@ lazy val messageDelivery = (project in file("./messagedelivery"))
   .dependsOn(common)
   .settings(
     name := "message-delivery",
+    scalaVersion := "2.11.8",
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.9.2",
       "com.amazonaws" % "aws-java-sdk" % "1.10.20"

--- a/capieventworker/src/main/resources/event.thrift
+++ b/capieventworker/src/main/resources/event.thrift
@@ -2,8 +2,6 @@ namespace scala com.gu.crier.model.event.v1
 
 include "content/v1.thrift"
 
-typedef string RemovedContent
-
 enum EventType {
     Update = 1,
     Delete = 2

--- a/capieventworker/src/main/resources/event.thrift
+++ b/capieventworker/src/main/resources/event.thrift
@@ -2,6 +2,8 @@ namespace scala com.gu.crier.model.event.v1
 
 include "content/v1.thrift"
 
+typedef string RemovedContent
+
 enum EventType {
     Update = 1,
     Delete = 2
@@ -11,17 +13,24 @@ enum ItemType {
     Content = 1,
     Tag = 2,
     Section = 3,
-    Front = 4,
-    StoryPackage = 5
+    StoryPackage = 4
+}
+
+union EventPayload {
+
+  1: v1.Content content
+
 }
 
 struct Event {
 
-    1: required EventType eventType
+    1: required string payloadId
 
-    2: required ItemType itemType
+    2: required EventType eventType
 
-    3: required i64 dateTime
+    3: required ItemType itemType
 
-    4: required v1.Content content
+    4: required i64 dateTime
+
+    5: optional EventPayload payload
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
 
 resolvers += "twitter-repo" at "https://maven.twttr.com"
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "3.16.3")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.6.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")


### PR DESCRIPTION
This work is to accommodate the change to the new CAPI V2 stream, which is using a different thrift model.

This PR updates the `event.thrift` model to match what `crier` uses, and also updates `libthrift` and `scrooge`.

#### Changes
 - Update scala version to 2.11.8
 - Updated Event thrift model
 - Update `Firehose` to handle new types
 - Update to CAPI client to `8.2`

@NathanielBennett @LATaylor-guardian 