### PR TITLE
Use riffRaffBuildIdentifier in sbt before doing any build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 jdk:
 - oraclejdk8
 script:
-- sbt clean test riffRaffUpload
+- sbt riffRaffBuildIdentifier clean test riffRaffUpload
 branches:
   only:
     - master


### PR DESCRIPTION
Needed to print out the `riffRaffBuildIdentifier`.