### PR TITLE
Add CAPI event worker healthcheck

### DIFF
--- a/capieventworker/app/controllers/CapiEventWorkerApplication.scala
+++ b/capieventworker/app/controllers/CapiEventWorkerApplication.scala
@@ -15,6 +15,8 @@ class CapiEventWorkerApplication @Inject() (capiEventWorker: CAPIKinesisStreamMo
 
   def info = Action {
     Ok(s"CAPI events Received: ${ServerStatistics.capiEventsReceived.get()}\n" +
-      s"CAPI Events Processed: ${ServerStatistics.capiEventsProcessed.get()}")
+      s"CAPI Events Processed: ${ServerStatistics.capiEventsProcessed.get()}\n" +
+      s"Last Event Received: ${ServerStatistics.lastCapiEventReceived.get}" +
+      s"Thrift Deserialisation Errors: ${ServerStatistics.thriftDeserialisationFailures}")
   }
 }

--- a/capieventworker/app/controllers/CapiEventWorkerApplication.scala
+++ b/capieventworker/app/controllers/CapiEventWorkerApplication.scala
@@ -16,7 +16,7 @@ class CapiEventWorkerApplication @Inject() (capiEventWorker: CAPIKinesisStreamMo
   def info = Action {
     Ok(s"CAPI events Received: ${ServerStatistics.capiEventsReceived.get()}\n" +
       s"CAPI Events Processed: ${ServerStatistics.capiEventsProcessed.get()}\n" +
-      s"Last Event Received: ${ServerStatistics.lastCapiEventReceived.get}" +
+      s"Last Event Received: ${ServerStatistics.lastCapiEventReceived.get}\n" +
       s"Thrift Deserialisation Errors: ${ServerStatistics.thriftDeserialisationFailures}")
   }
 }

--- a/capieventworker/app/controllers/Healthcheck.scala
+++ b/capieventworker/app/controllers/Healthcheck.scala
@@ -2,12 +2,23 @@ package controllers
 
 import javax.inject.Singleton
 
+import org.joda.time.DateTime
 import play.api.mvc.{Controller, Action}
+import services.ServerStatistics
 
 @Singleton
 class Healthcheck extends Controller {
 
+  val ConsecutiveErrorThreshold: Int = 10
+
   def healthcheck() = Action {
-    Ok("Ok")
+
+    if (ServerStatistics.lastCapiEventReceived.get.exists(lastReceived => DateTime.now.minusHours(1).isBefore(lastReceived))) {
+      InternalServerError(s"Have not successfully received a CAPI event since ${ServerStatistics.lastCapiEventReceived}")
+    } else if (ServerStatistics.thriftDeserialisationFailures.get >= ConsecutiveErrorThreshold) {
+      InternalServerError("Too many consecutive thrift parsing errors")
+    } else {
+      Ok("Everything is fine")
+    }
   }
 }

--- a/common/app/services/ServerStatistics.scala
+++ b/common/app/services/ServerStatistics.scala
@@ -7,4 +7,7 @@ object ServerStatistics {
   val capiEventsProcessed: AtomicLong = new AtomicLong(0L)
   val recordsProcessed: AtomicLong = new AtomicLong(0L)
   val gcmMessagesSent: AtomicLong = new AtomicLong(0L)
+
+  val lastCapiEventReceived: DateTimeRecorder = new DateTimeRecorder
+  val thriftDeserialisationFailures: AtomicLong = new AtomicLong(0L)
 }


### PR DESCRIPTION
This just adds some basic healthchecks to the `capiEventWorker`.

 - Too many consecutive thrift deserialisation errors
 - Have not last processed a message within the last hour

@NathanielBennett 