### PR TITLE
Clean up GcmId

### DIFF
--- a/common/app/helper/BrowserEndpoint.scala
+++ b/common/app/helper/BrowserEndpoint.scala
@@ -15,7 +15,6 @@ object BrowserEndpoint {
     endpointUrl match {
       case endpoint if endpoint.startsWith(ChromeEndpointPattern) => Option(ChromeEndpoint(endpoint))
       case endpoint if endpoint.startsWith(FirefoxEndpointPattern) => Option(FirefoxEndpoint(endpoint))
-      case endpointUrl: String if !endpointUrl.startsWith("http") => Option(GcmId(endpointUrl))
       case _ => None
     }
 }

--- a/common/app/helper/BrowserEndpoint.scala
+++ b/common/app/helper/BrowserEndpoint.scala
@@ -4,8 +4,7 @@ sealed trait BrowserEndpoint
 case class ChromeEndpoint(get: String) extends BrowserEndpoint
 case class FirefoxEndpoint(get: String) extends BrowserEndpoint
 
-//Temporary until we move completely to endpoints
-case class GcmId(get: String) extends BrowserEndpoint
+case class GcmId(get: String) extends AnyVal
 
 object BrowserEndpoint {
   private val ChromeEndpointPattern: String = "https://android.googleapis.com/gcm/send"

--- a/common/app/services/ClientDatabase.scala
+++ b/common/app/services/ClientDatabase.scala
@@ -42,8 +42,6 @@ class ClientDatabase @Inject()(
             itemMap.get("browserEndpoint")
               .map(_.getS)
               .flatMap(BrowserEndpoint.fromEndpointUrl)
-            .orElse {
-              itemMap.get("gcmBrowserId").map(_.getS).map(GcmId)}
         }.toList
 
         Option(queryResult.getLastEvaluatedKey) match {

--- a/common/app/workers/MessageWorker.scala
+++ b/common/app/workers/MessageWorker.scala
@@ -84,14 +84,6 @@ class MessageWorker @Inject() (
               redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
                 ServerStatistics.gcmMessagesSent.incrementAndGet()
                 gcmWorker.queue.send(List(gcmMessage))}}}
-        case FirefoxEndpoint(endpointUrl) => ()
-        case GcmId(gcmId) =>
-          keyEvents.map { keyEvent =>
-            val topicMessage: String = keyEvent.title.getOrElse(s"Message for $topic")
-            log.info(s"Message for $topic with Id: ${keyEvent.id}")
-            val gcmMessage: GCMMessage = GCMMessage(gcmId, topic, topicMessage, keyEvent.body, keyEvent.id)
-            redisMessageDatabase.leaveMessageWithDefaultExpiry(gcmMessage).map { _ =>
-              ServerStatistics.gcmMessagesSent.incrementAndGet()
-              gcmWorker.queue.send(List(gcmMessage))}}}}
+        case FirefoxEndpoint(endpointUrl) => ()}}
 
 }


### PR DESCRIPTION
This removes `GcmId` from the `BrowserEndpoint` ADT and turns it into a `value class`; only used to carry a `String`.

It also changes the `ClientDatabase` to never try and handle a row with `gcmBrowserId`; the `PROD` database no longer carries any `gcmBrowserId` keys.

@NathanielBennett 