### PR TITLE
Series Updates

### DIFF
--- a/common/app/model/Update.scala
+++ b/common/app/model/Update.scala
@@ -28,6 +28,7 @@ object KeyEvent {
 sealed trait Update
 case class PublishedMessage(topic: String) extends Update
 case class LiveBlogUpdateEvent(topic: String, keyEvents: List[KeyEvent]) extends Update
+case class SeriesUpdate(seriesTagId: String, seriesTitle: String, contentId: String, contentWebTitle: String) extends Update
 
 object Update {
   implicit val implicitFormat: Format[Update] = derived.oformat

--- a/common/app/services/LastSentDatabase.scala
+++ b/common/app/services/LastSentDatabase.scala
@@ -1,19 +1,10 @@
 package services
 
-import javax.inject.Inject
-
-import com.amazonaws.regions.{Regions, Region}
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.google.inject.Singleton
-import config.Config
 import helper.DynamoFormat.DynamoFormat
-import helper.DynamoLockingUpdateTable
 import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 sealed trait LastSent
 

--- a/common/app/services/LastSentDatabase.scala
+++ b/common/app/services/LastSentDatabase.scala
@@ -20,7 +20,7 @@ sealed trait LastSent
 case class LastSentDateOnly(topic: String, dateTime: DateTime) extends LastSent
 
 object LastSentDateOnly {
-  def emptyForTopic(topic: String): LastSent = LastSentDateOnly(topic, DateTime.now())
+  def emptyForTopic(topic: String): LastSentDateOnly = LastSentDateOnly(topic, DateTime.now())
 }
 
 case class LastSentKeyEvent(topic: String, dateTime: DateTime, keyEventId: Option[String]) extends LastSent

--- a/common/app/services/RedisMessageDatabase.scala
+++ b/common/app/services/RedisMessageDatabase.scala
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class RedisMessage(topic: String, title: String, body: String, blockId: String, time: Long)
+case class RedisMessage(topic: String, title: String, body: String, blockId: Option[String], time: Long)
 
 object RedisMessage {
   implicit val redisMessageFormat = Json.format[RedisMessage]

--- a/common/app/services/SeriesDatabase.scala
+++ b/common/app/services/SeriesDatabase.scala
@@ -1,0 +1,22 @@
+package services
+
+import javax.inject.Singleton
+
+import com.gu.contentapi.client.model.v1.{Tag, Content}
+import model.SeriesUpdate
+
+@Singleton
+class SeriesDatabase {
+
+  //Probably want this somewhere more manageable, like a database
+  private val seriesToNotifyOn: List[String] = List(
+    "artanddesign/series/art-weekly"
+  )
+
+  def tagsOfType(content: Content, tagType: String): List[Tag] = content.tags.filter(_.id == tagType).toList
+
+  def maybeSeriesUpdateFor(content: Content): Option[SeriesUpdate] =
+    content.tags.find(tag => seriesToNotifyOn.contains(tag.id)).map { tag =>
+      SeriesUpdate(tag.id, tag.webTitle, content.id, content.webTitle)}
+
+}

--- a/common/app/workers/GCMWorker.scala
+++ b/common/app/workers/GCMWorker.scala
@@ -17,7 +17,7 @@ object GCMMessage {
   implicit val implicitFormat = Json.format[GCMMessage]
 }
 
-case class GCMMessage(clientId: String, topic: String, title: String, body: String, blockId: String)
+case class GCMMessage(clientId: String, topic: String, title: String, body: String, blockId: Option[String])
 
 @Singleton
 class GCMWorker @Inject()(

--- a/messagedelivery/app/controllers/MessageDeliveryController.scala
+++ b/messagedelivery/app/controllers/MessageDeliveryController.scala
@@ -22,7 +22,7 @@ class MessageDeliveryController @Inject()(redis: RedisMessageDatabase) extends C
       "topic" -> nonEmptyText,
       "title" -> nonEmptyText,
       "body" -> nonEmptyText,
-      "blockId" -> nonEmptyText
+      "blockId" -> optional(nonEmptyText)
     )(GCMMessage.apply)(GCMMessage.unapply))
 
   def index = Action {

--- a/messageworker/app/controllers/MessageWorkerApplication.scala
+++ b/messageworker/app/controllers/MessageWorkerApplication.scala
@@ -48,7 +48,7 @@ class MessageWorkerApplication @Inject() (
       title <- requestMap.get("title").map(_.mkString)
       body <- requestMap.get("body").map(_.mkString)
       topicId <- requestMap.get("topicId").map(_.mkString)
-      blockId <- requestMap.get("blockId").map(_.mkString)
+      blockId = requestMap.get("blockId").map(_.mkString)
     } yield GCMMessage(browserId, topicId, title, body, blockId)
 
     maybeGCMMessage match {


### PR DESCRIPTION
This changes `Firehose` so that it now will start to handle **series updates**. (Series being a loose term).

What series to actually notify on are stored in `SeriesUpdateDatabase` which at the moment is just a `List[String]`.

This will intentionally notify a user for both a series update AND a live blog update from the ONE update.

Major Changes:
 - Make `blockId` optional throughout
 - Add `SeriesUpdate` to the `Update` ADT to handle series updates
 - Use `SeriesUpdate` to send series updates

This requires changes in `frontend`; in the case where `blockId` does not exist; currently in `frontend` `blockId` is always expected to exist.

@NathanielBennett @crifmulholland 