### PR TITLE
Reduce sentence size

### DIFF
--- a/common/app/model/Update.scala
+++ b/common/app/model/Update.scala
@@ -3,6 +3,7 @@ package model
 import com.gu.contentapi.client.model.v1.Content
 import julienrf.json.derived
 import play.api.libs.json.{Json, Format}
+import services.Sentences
 
 import scala.util.Try
 
@@ -11,13 +12,15 @@ case class KeyEvent(id: String, title: Option[String], body: String)
 object KeyEvent {
   implicit val implicitFormat: Format[KeyEvent] = Json.format[KeyEvent]
 
+  val keyEventBodySize: Int = 412
+
   def fromContent(content: Content): List[KeyEvent] =
     content.blocks
       .flatMap(_._2)
       .getOrElse(Nil)
       .filter(_.attributes.keyEvent.exists(identity))
       .filter(_.published)
-      .map(block => KeyEvent(block.id, block.title, block.bodyTextSummary))
+      .map(block => KeyEvent(block.id, block.title, Sentences.reduceToWithEllipsis(block.bodyTextSummary, keyEventBodySize)))
       .toList
       .reverse
 

--- a/common/app/services/Sentences.scala
+++ b/common/app/services/Sentences.scala
@@ -1,0 +1,9 @@
+package services
+
+object Sentences {
+
+  def reduceTo(sentencesInput: String, amountOfCharacters: Int): String =
+    sentencesInput.take(amountOfCharacters).reverse.dropWhile(_ != ' ').reverse
+
+  def reduceToWithEllipsis(sentencesInput: String, amountOfCharacters: Int): String = reduceTo(sentencesInput, amountOfCharacters) ++: "..."
+}

--- a/common/test/services/SentencesTest.scala
+++ b/common/test/services/SentencesTest.scala
@@ -1,0 +1,51 @@
+package services
+
+import org.scalatest.{Matchers, FreeSpec}
+
+class SentencesTest extends FreeSpec with Matchers {
+  val sentences: Seq[String] = Seq(
+    "Amy Cartel Land The Look of Silence What Happened, Miss Simone? Winter on Fire: Ukraine’s Fight for Freedom ",
+    "Well, Real finish with a 12th straight victory, but Barcelona have wrapped up a 3-0 victory at Granada, and the title is theirs. Congratulations to Luis Enrique and his team! ",
+    "That’s the whistle, and it’s official: Real finish second in La Liga ",
+    "46 min: Change for Real Madrid: James Rodriguez in for Cristiano Ronaldo. He’s got a week to prepare for the Champions League final, but also: the pichichi is Suarez’s. ",
+    "Adam McKay – The Big Short George Miller – Mad Max: Fury Road Alejandro González Iñárritu – The Revenant Lenny Abrahamson – Room Tom McCarthy – Spotlight "
+  )
+
+  val sentencesWithSpecificEndings: Seq[(String, String, String)] = Seq(
+    (
+      "Deportivo: Real finish",
+      "Deportivo: Real ",
+      "Deportivo: Real ..."
+      ),
+    (
+      "Tense moments in Spain ",
+      "Tense moments in Spain ",
+      "Tense moments in Spain ..."
+      ),
+    (
+      "Another day,",
+      "Another ",
+      "Another ..."
+      )
+  )
+
+  "Sentences reduceTo" - {
+    "should not touch the sentences" in {
+      sentences.foreach { sentence =>
+        Sentences.reduceTo(sentence, 412) should be (sentence)
+      }
+    }
+
+    "should reduce correctly down" in {
+      sentencesWithSpecificEndings.foreach { case (sentence, sentenceReducedToThree, _) =>
+        Sentences.reduceTo(sentence, 412) should be (sentenceReducedToThree)
+      }
+    }
+
+    "should reduce correctly down with added ellipsis" in {
+      sentencesWithSpecificEndings.foreach { case (sentence, _, sentenceWithEllipsis) =>
+        Sentences.reduceToWithEllipsis(sentence, 412) should be (sentenceWithEllipsis)
+      }
+    }
+  }
+}


### PR DESCRIPTION
When sending out notifications, if the sentence size is too long and the use has got a screen reader enabled for notifications, it reads the whole text. This isn't an issue for displaying the notifications on the screens, as the OS truncates it for us.

This just adds a pretty blunt `Sentences` object to reduce it down to `412` characters.

Why 412? Because it seems like a good length. I have asked the mobile team what would be a good truncation length in case this isn't appropriate.

@desbo @NathanielBennett @crifmulholland 